### PR TITLE
Fix path names.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 # Custom files you want to ignore go here
 # ==============================================================================
 
+# Executables in bin/ directory
+bin/
+
+# MuJoCo License Key and log
+mjkey.txt
+MUJOCO_LOG.TXT
+
 # Eclipse workspace
 .cproject
 .project
@@ -97,14 +104,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-# ==============================================================================
-# MuJoCo
-# ==============================================================================
-
-# Ignore all executable files and the license file in bin/
-bin/
-model/mjkey.txt
 
 # ==============================================================================
 # Python

--- a/model/cassie2d_stiff.xml
+++ b/model/cassie2d_stiff.xml
@@ -1,6 +1,6 @@
 <!-- Note: Component inertias are known to be incorrect in this version -->
 <mujoco model='cassie'>
-  <compiler inertiafromgeom='false' angle='degree' eulerseq='zyx' meshdir='/home/tapgar/workspace/ThirdParty/mjpro150/model/cassie-stl-meshes'/>
+  <compiler inertiafromgeom='false' angle='degree' eulerseq='zyx' meshdir='cassie-stl-meshes'/>
   <size nuser_actuator='1' nuser_sensor='1'/>
   <option timestep='0.0005' iterations='50' solver='PGS' cone='elliptic' gravity='0 0 -9.806'/>
   <!-- Timestep is set to 0.0005 because our controller runs at 2 kHz -->

--- a/model/cassie3d_stiff.xml
+++ b/model/cassie3d_stiff.xml
@@ -1,6 +1,6 @@
 <!-- Note: Component inertias are known to be incorrect in this version -->
 <mujoco model='cassie'>
-  <compiler inertiafromgeom='false' angle='degree' eulerseq='zyx' meshdir='cassie-stl-meshes-lowres'/>
+  <compiler inertiafromgeom='false' angle='degree' eulerseq='zyx' meshdir='cassie-stl-meshes'/>
   <size nuser_actuator='1' nuser_sensor='1'/>
   <option timestep='0.0005' iterations='50' solver='PGS' cone='elliptic' gravity='0 0 -9.806'/>
   <!-- Timestep is set to 0.0005 because our controller runs at 2 kHz -->

--- a/src/Cassie2d/Cassie2d.cpp
+++ b/src/Cassie2d/Cassie2d.cpp
@@ -7,9 +7,9 @@
 
 #include "Cassie2d.h"
 
-// use relative paths. Put your MuJoCo key inside /model
-const char* MUJOCO_LICENSE_PATH = "/model/mjkey.txt";
-const char* XML_FILE_PATH = "/model/cassie2d_stiff.xml";
+// change this to where your files are. Use ABSOLUTE path!
+const char* MUJOCO_LICENSE_PATH = "home/phi/work/cassierl/model/mjkey.txt";
+const char* XML_FILE_PATH = "home/phi/work/cassierl/model/cassie2d_stiff.xml";
 
 /*
  * external functions used by python interface

--- a/src/Cassie2d/Cassie2d.cpp
+++ b/src/Cassie2d/Cassie2d.cpp
@@ -8,8 +8,8 @@
 #include "Cassie2d.h"
 
 // change this to where your files are. Use ABSOLUTE path!
-const char* MUJOCO_LICENSE_PATH = "home/phi/work/cassierl/model/mjkey.txt";
-const char* XML_FILE_PATH = "home/phi/work/cassierl/model/cassie2d_stiff.xml";
+const char* MUJOCO_LICENSE_PATH = "/home/phi/work/cassierl/model/mjkey.txt";
+const char* XML_FILE_PATH = "/home/phi/work/cassierl/model/cassie2d_stiff.xml";
 
 /*
  * external functions used by python interface

--- a/src/Cassie2d/RobotInterface.h
+++ b/src/Cassie2d/RobotInterface.h
@@ -10,6 +10,8 @@
 
 #include <string>
 
+// Change this to where your files are. Use ABSOLUTE path!
+static const std::string xml_model_filename = "home/phi/work/cassierl/model/cassie2d_stiff.xml";
 
 struct ControllerTorque {
   double torques[6];
@@ -57,7 +59,6 @@ struct StateOperationalSpace {
 
 #define DOF 3 // 2D vs 3D
 
-static const std::string xml_model_filename = "/home/tapgar/workspace/RLProject/model/cassie2d_stiff.xml";
 static const double mu = 0.5;
 
 static void StateOperationalSpaceToArray(StateOperationalSpace* state, double* pos, double* vel)

--- a/src/Cassie2d/RobotInterface.h
+++ b/src/Cassie2d/RobotInterface.h
@@ -11,7 +11,7 @@
 #include <string>
 
 // Change this to where your files are. Use ABSOLUTE path!
-static const std::string xml_model_filename = "home/phi/work/cassierl/model/cassie2d_stiff.xml";
+static const std::string xml_model_filename = "/home/phi/work/cassierl/model/cassie2d_stiff.xml";
 
 struct ControllerTorque {
   double torques[6];


### PR DESCRIPTION
Put all paths near the beginning of corresponding files, thus making them easy to change by various users. For now, we need to use absolute paths and get the job done, then we'll come back and figure out a way to work around these path complications later.