### PR TITLE
Add rendering method directly into Python interface

### DIFF
--- a/rllab/envs/cassie2d.py
+++ b/rllab/envs/cassie2d.py
@@ -159,21 +159,3 @@ class Cassie2dEnv(Env):
         high = np.full((6,), 1e2) #accel of 100 may be reasonable
         low = -high
         return Box(low, high)
-
-def main():
-    env = Cassie2dEnv()
-    env.reset()
-
-    freq = 0.5
-    w = freq*3.1415
-    t = 0.0
-
-    while (True):
-        env.standing_controller_jacobian(0.7 + 0.25*np.sin(w*t), 0.25*np.cos(w*t))
-        t = t + 0.0005
-
-
-
-
-if __name__ == "__main__":
-    main()

--- a/rllab/envs/cassie2d.py
+++ b/rllab/envs/cassie2d.py
@@ -76,9 +76,11 @@ class Cassie2dEnv(Env):
         sp = self.cvrt.operational_state_to_array(self.xstate)
 
         #reward (do something here)
-        r=0.0
+        r = (0.9 - self.xstate.body_x[1])**2
         #done (do something here)
-        done=False
+        done = False
+        if (self.xstate.body_x[1] < 0.2):
+            done = True
 
         return Step(observation=sp, reward=r, done=done)
 
@@ -155,6 +157,6 @@ class Cassie2dEnv(Env):
 
     @cached_property
     def action_space(self):
-        high = np.full((6,), 1e2) #accel of 100 may be reasonable
+        high = np.full((7,), 1e2) #accel of 100 may be reasonable
         low = -high
         return Box(low, high)

--- a/rllab/envs/cassie2d.py
+++ b/rllab/envs/cassie2d.py
@@ -62,7 +62,6 @@ class Cassie2dEnv(Env):
         lib.Reset(self.cassie, self.qstate)
 
     def step(self, action):
-
         #convert action
         self.action_osc = self.cvrt.array_to_operational_action(action)
 
@@ -83,8 +82,10 @@ class Cassie2dEnv(Env):
 
         return Step(observation=sp, reward=r, done=done)
 
-    def standing_controller_osc(self, zpos_target, zvel_target):
+    def render(self):
+        lib.Render(self.cassie)
 
+    def standing_controller_osc(self, zpos_target, zvel_target):
         #get operational state
         lib.GetOperationalSpaceState(self.cassie, ctypes.byref(self.xstate))
 
@@ -114,7 +115,6 @@ class Cassie2dEnv(Env):
         lib.StepOsc(self.cassie, ctypes.byref(self.action_osc))
 
     def standing_controller_jacobian(self, zpos_target, zvel_target):
-
         #get operational state
         lib.GetOperationalSpaceState(self.cassie, ctypes.byref(self.xstate))
 
@@ -152,7 +152,6 @@ class Cassie2dEnv(Env):
         high = np.full((18,), 1e20)
         low = -high
         return Box(low, high)
-
 
     @cached_property
     def action_space(self):

--- a/rllab/envs/random_agent.py
+++ b/rllab/envs/random_agent.py
@@ -1,0 +1,45 @@
+"""
+Adapted from OpenAI Gym's random_agent.py.
+This thing will never work unless you're lucky.
+"""
+
+import argparse
+import sys
+from cassie2d import Cassie2dEnv
+
+import gym
+from gym import wrappers, logger
+
+
+def main():
+    env = Cassie2dEnv()
+    env.reset()
+
+    agent = RandomAgent(env.action_space)
+    episode_count = 100
+    reward = 0
+    done = False
+
+    for episode in range(episode_count):
+        ob = env.reset()
+        while True:
+            action = agent.act(ob, reward, done)
+            ob, reward, done, info = env.step(action)
+            print(episode)
+            env.render()
+            if done:
+                break
+
+
+class RandomAgent(object):
+    """The world's simplest agent!"""
+
+    def __init__(self, action_space):
+        self.action_space = action_space
+
+    def act(self, observation, reward, done):
+        return self.action_space.sample()
+
+
+if __name__ == '__main__':
+    main()

--- a/rllab/envs/squatting.py
+++ b/rllab/envs/squatting.py
@@ -1,0 +1,17 @@
+"""
+Makes Cassie squat up and down. This is purely physics. There is no RL involved.
+"""
+
+import cassie2d
+import numpy as np
+
+env = cassie2d.Cassie2dEnv()
+env.reset()
+
+freq = 0.5
+w = freq*3.1415
+t = 0.0
+
+while (True):
+    env.standing_controller_jacobian(0.7 + 0.25*np.sin(w*t), 0.25*np.cos(w*t))
+    t = t + 0.0005

--- a/src/Cassie2d/Cassie2d.cpp
+++ b/src/Cassie2d/Cassie2d.cpp
@@ -25,7 +25,7 @@ void StepJacobian(Cassie2d* cassie, ControllerForce* action) { cassie->StepJacob
 void GetGeneralState(Cassie2d* cassie, StateGeneral* state) { cassie->GetGeneralState(state); }
 void GetOperationalSpaceState(Cassie2d* cassie, StateOperationalSpace* state) { cassie->GetOperationalSpaceState(state); }
 void Display(Cassie2d* cassie, bool display) { cassie->display_ = display; }
-
+void Render(Cassie2d* cassie) { cassie->Render(); }
 }
 
 Cassie2d::Cassie2d() {
@@ -80,6 +80,8 @@ void Cassie2d::Reset(StateGeneral* state)
   StateGeneralToArray(state, mj_data_->qpos, mj_data_->qvel);
   mj_forward(mj_model_, mj_data_);
 }
+
+void Cassie2d::Render() { if (display_) vis_->Draw(mj_data_); }
 
 void Cassie2d::Step(ControllerTorque* action)
 {
@@ -144,9 +146,7 @@ void Cassie2d::StepJacobian(ControllerForce* action)
 
   mj_step(mj_model_, mj_data_);
 
-  if (display_)
-    vis_->Draw(mj_data_);
-
+  Render();
 }
 
 void Cassie2d::StepOsc(ControllerOsc* action)
@@ -178,9 +178,7 @@ void Cassie2d::StepOsc(ControllerOsc* action)
 
   mj_step(mj_model_, mj_data_);
 
-  if (display_)
-    vis_->Draw(mj_data_);
-
+  Render();
 }
 
 

--- a/src/Cassie2d/Cassie2d.h
+++ b/src/Cassie2d/Cassie2d.h
@@ -21,6 +21,7 @@ public:
   virtual ~Cassie2d();
 
   void Reset(StateGeneral* state);
+  void Render();
   void StepOsc(ControllerOsc* action);
   void StepJacobian(ControllerForce* action);
   void Step(ControllerTorque* action);


### PR DESCRIPTION
In `Cassie2d.cpp`, instead of repeatedly using `if (display_) vis_->Draw(mj_data);`, I implement an additional method `Render()` for `Cassie2d` class that does the exact same thing.

I also add `Render()` to the Python interface and implement a method for `Cassie2dEnv` class of Python.

So, whenever we need to render anything in python, just call `env.render()`.